### PR TITLE
ci: install and run ruff explicitly instead of via action

### DIFF
--- a/.github/workflows/python-poetry-package.yml
+++ b/.github/workflows/python-poetry-package.yml
@@ -26,20 +26,14 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Install project
-      run: poetry install --without dev
-    - name: Test with pytest
-      run: |
-        source $VENV
-        pytest
-    - name: Check typing with mypy
-      run: |
-        source $VENV
-        mypy .
+      run: poetry install
     - name: Lint with ruff
-      # by default: exit with error if rule violations
-      uses: chartboost/ruff-action@v1
+      # by default, exit with error if rule violations.
+      run: poetry run ruff check
     - name: Format check with ruff
-      # by default: exit with error if rule violations
-      uses: chartboost/ruff-action@v1
-      with:
-        args: format
+      # by default, exit with error if the code is not properly formatted.
+      run: poetry run ruff format --check --diff
+    - name: Check typing with mypy
+      run: poetry run mypy .
+    - name: Test with pytest
+      run: poetry run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,8 @@ pdoc = "^15.0.0"
 pre-commit = "^4.0.1"
 pydoclint = "^0.5.10"
 pydoctest = "^0.2.1"
-ruff = "^0.8.2"
-
-[tool.poetry.group.test.dependencies]
 pytest = "^8.3.4"
-mypy = "^1.13.0"  # match dev dependency value
+ruff = "^0.8.2"
 
 [tool.mypy]
 ## Config file:


### PR DESCRIPTION
In order to use the version specified in dev-deps